### PR TITLE
Fixed a couple of "derp" bugs

### DIFF
--- a/tests/test_reaper.py
+++ b/tests/test_reaper.py
@@ -33,7 +33,6 @@ class TestReapSnapshots(unittest.TestCase):
         cls.logger = MagicMock()
         cls.vcenter = MagicMock()
         fake_vm = MagicMock()
-        fake_vm.snapshot = True
         fake_vms = MagicMock()
         fake_vms.childEntity = [fake_vm]
         fake_user = MagicMock()

--- a/vlab_snapshot_api/lib/worker/vmware.py
+++ b/vlab_snapshot_api/lib/worker/vmware.py
@@ -123,10 +123,10 @@ def create_snapshot(username, machine_name, shift, logger):
                     return {machine_name: [{'id': snap_id,
                                             'created': created,
                                             'expires': expires}]}
-            else:
-                error = 'No VM named {} found in inventory'.format(machine_name)
-                logger.info(error)
-                raise ValueError(error)
+        else:
+            error = 'No VM named {} found in inventory'.format(machine_name)
+            logger.info(error)
+            raise ValueError(error)
 
 
 def _take_snapshot(the_vm, dump_memory=True, quiesce=False, description=''):


### PR DESCRIPTION
While updating the CLI, I found a bug where the Snapshot API returned an error if the 1st VM it finds in a user's inventory is not the VM requested to be snapshotted. Basically, I had the `else` clause of the name check, instead of the `for` loop.

While running the unit tests, I found a bad mock of the snapshot object; simple enough fix.